### PR TITLE
Rollback to old style of constructor

### DIFF
--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -26,15 +26,6 @@ abstract class Adapter
     abstract public function getName(): string;
 
     /**
-     * Adapter constructor.
-     * 
-     * @param string $configuration
-     * 
-     * @return Adapter
-     */
-    abstract public function __construct(string $configuration);
-
-    /**
      * Enables tracking for this instance.
      * 
      * @return void

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -51,21 +51,16 @@ class ActiveCampaign extends Adapter
     }
 
     /**
-     * @param string $configuration 
+     * @param string $key 
+     * @param string $actid
      * Adapter configuration
      * 
      * @return ActiveCampaign
      */
-    public function __construct(string $configuration)
+    public function __construct(string $key, string $actid)
     {
-        $data = explode(',', $configuration);
-        $data = array_map(function($item) {
-            return explode('=', $item);
-        }, $data);
-        $data = array_combine(array_column($data, 0), array_column($data, 1));
-
-        $this->key = $data['key'];
-        $this->actid = $data['actid'];
+        $this->key = $key;
+        $this->actid = $actid;
     }
 
     /**

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -48,21 +48,16 @@ class GoogleAnalytics extends Adapter
     }
 
     /**
-     * @param string $configuration 
+     * @param string $tid 
+     * @param string $cid
      * Adapter configuration
      * 
      * @return GoogleAnalytics
      */
-    public function __construct(string $configuration)
+    public function __construct(string $tid, string $cid)
     {
-        $data = explode(',', $configuration);
-        $data = array_map(function($item) {
-            return explode('=', $item);
-        }, $data);
-        $data = array_combine(array_column($data, 0), array_column($data, 1));
-
-        $this->tid = $data['tid'];
-        $this->cid = $data['cid'];
+        $this->tid = $tid;
+        $this->cid = $cid;
     }
 
     /**

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -25,8 +25,8 @@ class AnalyticsTest extends TestCase
 
     public function setUp(): void
     {
-        $this->ga = new GoogleAnalytics("tid=UA-XXXXXXXXX-X,cid=test");
-        $this->ac = new ActiveCampaign("key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,actid=xxxxxxxxx");
+        $this->ga = new GoogleAnalytics("UA-XXXXXXXXX-X", "test");
+        $this->ac = new ActiveCampaign("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "xxxxxxxxx");
     }
 
     public function testGoogleAnalytics()


### PR DESCRIPTION
This PR turns the `$string configuration` param for constructors back into their old ones