### PR TITLE
Add Contact methods to Active Campaign adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "psr-4": {"Utopia\\Analytics\\": "src/Analytics"}
     },
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "utopia-php/cli": "^0.13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -33,7 +33,7 @@ abstract class Adapter
      * @var array
      */
     protected $headers = [
-        'content-type' => '',
+        'Content-Type' => '',
     ];
 
     /**
@@ -85,7 +85,7 @@ abstract class Adapter
         $responseType       = '';
         $responseBody       = '';
 
-        switch ($headers['content-type']) {
+        switch ($headers['Content-Type']) {
             case 'application/json':
                 $query = json_encode($params);
                 break;
@@ -127,7 +127,7 @@ abstract class Adapter
         }
 
         $responseBody   = curl_exec($ch);
-        $responseType   = $responseHeaders['content-type'] ?? '';
+        $responseType   = $responseHeaders['Content-Type'] ?? '';
         $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         
         switch(substr($responseType, 0, strpos($responseType, ';'))) {

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -76,7 +76,7 @@ abstract class Adapter
      * @return array|string
      * @throws Exception
      */
-    public function call($method, $path = '', $headers = array(), array $params = array())
+    public function call(string $method, string $path = '', array $headers = array(), array $params = array()): array|string
     {
         $headers            = array_merge($this->headers, $headers);
         $ch                 = curl_init((str_contains($path, 'http') ? $path : $this->endpoint . $path . (($method == 'GET' && !empty($params)) ? '?' . http_build_query($params) : '')));

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -14,6 +14,8 @@
 
 namespace Utopia\Analytics;
 
+use Exception;
+
 abstract class Adapter
 {
     protected bool $enabled = true;
@@ -24,6 +26,15 @@ abstract class Adapter
      * @return string
      */
     abstract public function getName(): string;
+
+    /**
+     * Global Headers
+     *
+     * @var array
+     */
+    protected $headers = [
+        'content-type' => '',
+    ];
 
     /**
      * Enables tracking for this instance.
@@ -52,5 +63,119 @@ abstract class Adapter
      * @return bool
      */
     abstract public function createEvent(Event $event): bool;
+
+    /**
+     * Call
+     *
+     * Make an API call
+     *
+     * @param string $method
+     * @param string $path
+     * @param array $params
+     * @param array $headers
+     * @return array|string
+     * @throws Exception
+     */
+    public function call($method, $path = '', $headers = array(), array $params = array())
+    {
+        $headers            = array_merge($this->headers, $headers);
+        $ch                 = curl_init((str_contains($path, 'http') ? $path : $this->endpoint . $path . (($method == 'GET' && !empty($params)) ? '?' . http_build_query($params) : '')));
+        $responseHeaders    = [];
+        $responseStatus     = -1;
+        $responseType       = '';
+        $responseBody       = '';
+
+        switch ($headers['content-type']) {
+            case 'application/json':
+                $query = json_encode($params);
+                break;
+
+            case 'multipart/form-data':
+                $query = $this->flatten($params);
+                break;
+
+            default:
+                $query = http_build_query($params);
+                break;
+        }
+
+        foreach ($headers as $i => $header) {
+            $headers[] = $i . ':' . $header;
+            unset($headers[$i]);
+        }
+
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_USERAGENT, php_uname('s') . '-' . php_uname('r') . ':php-' . phpversion());
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$responseHeaders) {
+            $len = strlen($header);
+            $header = explode(':', strtolower($header), 2);
+
+            if (count($header) < 2) { // ignore invalid headers
+                return $len;
+            }
+
+            $responseHeaders[strtolower(trim($header[0]))] = trim($header[1]);
+
+            return $len;
+        });
+
+        if($method != 'GET') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
+        }
+
+        $responseBody   = curl_exec($ch);
+        $responseType   = $responseHeaders['content-type'] ?? '';
+        $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        
+        switch(substr($responseType, 0, strpos($responseType, ';'))) {
+            case 'application/json':
+                $responseBody = json_decode($responseBody, true);
+            break;
+        }
+
+        if (curl_errno($ch)) {
+            throw new Exception(curl_error($ch));
+        }
+        
+        curl_close($ch);
+
+        if($responseStatus >= 400) {
+            if(is_array($responseBody)) {
+                throw new Exception(json_encode($responseBody));
+            } else {
+                throw new Exception($responseStatus . ': ' . $responseBody);
+            }
+        }
+
+
+        return $responseBody;
+    }
+
+    /**
+     * Flatten params array to PHP multiple format
+     *
+     * @param array $data
+     * @param string $prefix
+     * @return array
+     */
+    protected function flatten(array $data, $prefix = '') {
+        $output = [];
+
+        foreach($data as $key => $value) {
+            $finalKey = $prefix ? "{$prefix}[{$key}]" : $key;
+
+            if (is_array($value)) {
+                $output += $this->flatten($value, $finalKey); // @todo: handle name collision here if needed
+            }
+            else {
+                $output[$finalKey] = $value;
+            }
+        }
+
+        return $output;
+    }
 
 }

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -14,8 +14,6 @@
 
 namespace Utopia\Analytics;
 
-use Exception;
-
 abstract class Adapter
 {
     protected bool $enabled = true;
@@ -74,7 +72,7 @@ abstract class Adapter
      * @param array $params
      * @param array $headers
      * @return array|string
-     * @throws Exception
+     * @throws \Exception
      */
     public function call(string $method, string $path = '', array $headers = array(), array $params = array()): array|string
     {
@@ -137,16 +135,16 @@ abstract class Adapter
         }
 
         if (curl_errno($ch)) {
-            throw new Exception(curl_error($ch));
+            throw new \Exception(curl_error($ch));
         }
         
         curl_close($ch);
 
         if($responseStatus >= 400) {
             if(is_array($responseBody)) {
-                throw new Exception(json_encode($responseBody));
+                throw new \Exception(json_encode($responseBody));
             } else {
-                throw new Exception($responseStatus . ': ' . $responseBody);
+                throw new \Exception($responseStatus . ': ' . $responseBody);
             }
         }
 

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -110,7 +110,7 @@ class ActiveCampaign extends Adapter
 
         try {
             $this->call('POST', '/api/3/contacts', [
-                'content-type' => 'application/json'
+                'Content-Type' => 'application/json'
             ], $body);
             return true;
         } catch (\Exception $e) {
@@ -141,7 +141,7 @@ class ActiveCampaign extends Adapter
 
         try {
             $this->call('PUT', '/api/3/contacts/'.$contactId, [
-                'content-type' => 'application/json'
+                'Content-Type' => 'application/json'
             ], $body);
 
             return true;
@@ -220,7 +220,7 @@ class ActiveCampaign extends Adapter
 
         try {
             $this->call('POST', '/api/3/accounts', [
-                'content-type' => 'application/json'
+                'Content-Type' => 'application/json'
             ], $body);
             return true;
         } catch (\Exception $e) {
@@ -253,7 +253,7 @@ class ActiveCampaign extends Adapter
 
         try {
             $this->call('PUT', '/api/3/accounts/'.$accountId, [
-                'content-type' => 'application/json',
+                'Content-Type' => 'application/json',
             ], array_filter($body));
             return true;
         } catch (\Exception $e) {
@@ -311,7 +311,7 @@ class ActiveCampaign extends Adapter
 
             try {
                 $result = $this->call('PUT', '/api/3/accountContacts/'.$associationId, [
-                    'content-type' => 'application/json',
+                    'Content-Type' => 'application/json',
                 ], [
                     'accountContact' => [
                         'jobTitle' => $role
@@ -325,7 +325,7 @@ class ActiveCampaign extends Adapter
         } else {
             // Create the association
             $result = $this->call('POST', '/api/3/accountContacts', [
-                'content-type' => 'application/json',
+                'Content-Type' => 'application/json',
             ], ['accountContact' => [
                 'account' => $accountId,
                 'contact' => $contactId,
@@ -355,7 +355,7 @@ class ActiveCampaign extends Adapter
         $this->endpoint = 'https://'.$organisationID.'.api-us1.com/';
         $this->headers = [
             'api-token' => $this->apiKey,
-            'content-type' => null
+            'Content-Type' => null
         ];
     }
 

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -27,7 +27,7 @@ class ActiveCampaign extends Adapter
      *  Endpoint for ActiveCampaign
      *  @var string
      */
-    public string $endpoint = 'https://trackcmp.net/event';
+    public string $endpoint;
 
     /**
      * Event Key for ActiveCampaign
@@ -46,12 +46,6 @@ class ActiveCampaign extends Adapter
      * @var string
      */
     private string $apiKey;
-
-    /**
-     * ActiveCampaign Email
-     * @var string
-     */
-    private string $email;
 
     /**
      * Gets the name of the adapter.
@@ -176,10 +170,10 @@ class ActiveCampaign extends Adapter
     /**
      * Account Exists
      * 
-     * @param string $domain
+     * @param string $name
      * @return bool|int
      */
-    public function accountExists($name): bool|int
+    public function accountExists(string $name): bool|int
     {
         try {
             $result = $this->call('GET', '/api/3/accounts', [], [
@@ -341,18 +335,15 @@ class ActiveCampaign extends Adapter
      * @param string $actid
      * @param string $apiKey
      * @param string $organisationID
-     * @param string $email
      * 
      * @return ActiveCampaign
      */
-    public function __construct(string $key, string $actid, string $apiKey, string $organisationID, string $email)
+    public function __construct(string $key, string $actid, string $apiKey, string $organisationID)
     {
         $this->key = $key;
         $this->actid = $actid;
-        $this->email = $email;
         $this->apiKey = $apiKey;
-        $this->organisationID = $organisationID;
-        $this->endpoint = 'https://'.$organisationID.'.api-us1.com/';
+        $this->endpoint = 'https://'.$organisationID.'.api-us1.com/'; // ActiveCampaign API URL, Refer to https://developers.activecampaign.com/reference/url for more details.
         $this->headers = [
             'api-token' => $this->apiKey,
             'Content-Type' => null
@@ -382,7 +373,7 @@ class ActiveCampaign extends Adapter
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');
 
         try {
-            $this->call('POST', 'https://trackcmp.net/event', [], $query);
+            $this->call('POST', 'https://trackcmp.net/event', [], $query); // Active Campaign event URL, Refer to https://developers.activecampaign.com/reference/track-event/ for more details
             return true;
         } catch (\Exception $e) {
             Console::error($e->getMessage());

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -79,7 +79,11 @@ class ActiveCampaign extends Adapter
                 return false;
             }
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -108,7 +112,11 @@ class ActiveCampaign extends Adapter
             ], $body);
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -140,7 +148,11 @@ class ActiveCampaign extends Adapter
 
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -162,7 +174,11 @@ class ActiveCampaign extends Adapter
             $this->call('DELETE', '/api/3/contacts/'.$contact);
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -186,7 +202,11 @@ class ActiveCampaign extends Adapter
                 return false;
             }
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -218,7 +238,11 @@ class ActiveCampaign extends Adapter
             ], $body);
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -251,7 +275,11 @@ class ActiveCampaign extends Adapter
             ], array_filter($body));
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -269,7 +297,11 @@ class ActiveCampaign extends Adapter
             $this->call('DELETE', '/api/3/accounts/'.$accountId);
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }
@@ -295,7 +327,11 @@ class ActiveCampaign extends Adapter
                 'filters[contact]' => $contactId
             ]);
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
 
@@ -313,7 +349,11 @@ class ActiveCampaign extends Adapter
                 ]);
                 return true;
             } catch (\Exception $e) {
-                Console::error($e->getMessage());
+                Console::error('[Error] ActiveCampaign Analytics Error: ');
+                Console::error('[Error] Type: ' . get_class($e));
+                Console::error('[Error] Message: ' . $e->getMessage());
+                Console::error('[Error] File: ' . $e->getFile());
+                Console::error('[Error] Line: ' . $e->getLine());
                 return false;
             }
         } else {
@@ -376,7 +416,11 @@ class ActiveCampaign extends Adapter
             $this->call('POST', 'https://trackcmp.net/event', [], $query); // Active Campaign event URL, Refer to https://developers.activecampaign.com/reference/track-event/ for more details
             return true;
         } catch (\Exception $e) {
-            Console::error($e->getMessage());
+            Console::error('[Error] ActiveCampaign Analytics Error: ');
+            Console::error('[Error] Type: ' . get_class($e));
+            Console::error('[Error] Message: ' . $e->getMessage());
+            Console::error('[Error] File: ' . $e->getFile());
+            Console::error('[Error] Line: ' . $e->getLine());
             return false;
         }
     }

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -19,6 +19,7 @@ namespace Utopia\Analytics\Adapter;
 
 use Utopia\Analytics\Adapter;
 use Utopia\Analytics\Event;
+use Utopia\CLI\Console;
 
 class ActiveCampaign extends Adapter
 {
@@ -84,6 +85,7 @@ class ActiveCampaign extends Adapter
                 return false;
             }
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -112,7 +114,7 @@ class ActiveCampaign extends Adapter
             ], $body);
             return true;
         } catch (\Exception $e) {
-            throw $e;
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -144,6 +146,7 @@ class ActiveCampaign extends Adapter
 
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -165,6 +168,7 @@ class ActiveCampaign extends Adapter
             $this->call('DELETE', '/api/3/contacts/'.$contact);
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -188,6 +192,7 @@ class ActiveCampaign extends Adapter
                 return false;
             }
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -197,8 +202,8 @@ class ActiveCampaign extends Adapter
      * 
      * @param string $name
      * @param string $url
-     * @param string $ownerID
-     * @param string $fields
+     * @param int $ownerID
+     * @param array $fields
      * 
      * @return bool
      */
@@ -219,6 +224,7 @@ class ActiveCampaign extends Adapter
             ], $body);
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -251,6 +257,7 @@ class ActiveCampaign extends Adapter
             ], array_filter($body));
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -268,6 +275,7 @@ class ActiveCampaign extends Adapter
             $this->call('DELETE', '/api/3/accounts/'.$accountId);
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }
@@ -293,6 +301,7 @@ class ActiveCampaign extends Adapter
                 'filters[contact]' => $contactId
             ]);
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
 
@@ -310,6 +319,7 @@ class ActiveCampaign extends Adapter
                 ]);
                 return true;
             } catch (\Exception $e) {
+                Console::error($e->getMessage());
                 return false;
             }
         } else {
@@ -375,6 +385,7 @@ class ActiveCampaign extends Adapter
             $this->call('POST', 'https://trackcmp.net/event', [], $query);
             return true;
         } catch (\Exception $e) {
+            Console::error($e->getMessage());
             return false;
         }
     }

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -207,7 +207,7 @@ class ActiveCampaign extends Adapter
      * 
      * @return bool
      */
-    public function createAccount($name, $url = '', $ownerID = 1, $fields = []): bool
+    public function createAccount(string $name, string $url = '', int $ownerID = 1, array $fields = []): bool
     {
         $body = ['account' => [
             'name' => $name,

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -41,6 +41,24 @@ class ActiveCampaign extends Adapter
     private string $actid;
 
     /**
+     * ActiveCampaign apiKey
+     * @var string
+     */
+    private string $apiKey;
+
+    /**
+     * ActiveCampaign Organisation ID
+     * @var string
+     */
+    private string $organisationID;
+
+    /**
+     * ActiveCampaign Email
+     * @var string
+     */
+    private string $email;
+
+    /**
      * Gets the name of the adapter.
      * 
      * @return string
@@ -50,6 +68,111 @@ class ActiveCampaign extends Adapter
         return 'ActiveCampaign';
     }
 
+
+    /**
+     * Checks if a contact exists and returns a bool if it does.
+     * 
+     * @param string $email
+     * @return bool|int
+     */
+    public function contactExists(string $email): bool|int
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://'.$this->organisationID.'.api-us1.com/api/3/contacts?'.http_build_query([
+            'email' => $email
+        ]));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET' );
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Api-Token: '.$this->apiKey
+        ]);
+
+        $body = curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            return false;
+        }
+
+        if (json_decode($body, true)['meta']['total'] > 0) {
+            return (json_decode($body, true))['contacts'][0]['id'];
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Create a contact
+     * 
+     * @param string $email
+     * @param string $firstName
+     * @param string $lastName
+     * @return bool
+     */
+    public function createContact(string $email, string $firstName, string $lastName): bool
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://'.$this->organisationID.'.api-us1.com/api/3/contacts');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(['contact' => [
+            'email' => $email,
+            'firstName' => $firstName,
+            'lastName' => $lastName
+        ]]));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Api-Token: '.$this->apiKey
+        ]);
+
+        curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            return false;
+        }
+
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($statusCode == 201) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** 
+     * Delete a contact 
+     * 
+     * @param string $email
+     * @return bool
+     */
+    public function deleteContact($email): bool {
+        $contact = $this->contactExists($email);
+
+        if (!$contact) {
+            return false;
+        }
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://'.$this->organisationID.'.api-us1.com/api/3/contacts/'.$contact);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Api-Token: '.$this->apiKey
+        ]);
+
+        curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            return false;
+        }
+
+        if (curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /**
      * @param string $key 
      * @param string $actid
@@ -57,10 +180,13 @@ class ActiveCampaign extends Adapter
      * 
      * @return ActiveCampaign
      */
-    public function __construct(string $key, string $actid)
+    public function __construct(string $key, string $actid, string $apiKey, string $organisationID, string $email)
     {
         $this->key = $key;
         $this->actid = $actid;
+        $this->email = $email;
+        $this->apiKey = $apiKey;
+        $this->organisationID = $organisationID;
     }
 
     /**

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -147,6 +147,7 @@ class ActiveCampaign extends Adapter
     /**
      * Update contact
      * 
+     * @param string $contactId
      * @param string $email
      * @param string $firstName
      * @param string $lastName
@@ -154,7 +155,7 @@ class ActiveCampaign extends Adapter
      * 
      * @return bool
      */
-    public function updateContact(string $contactId, string $email = '', string $firstName = '', string $lastName = '', string $phone = ''): bool
+    public function updateContact(string $contactId, string $email, string $firstName = '', string $lastName = '', string $phone = ''): bool
     {
         $ch = curl_init();
 
@@ -174,7 +175,7 @@ class ActiveCampaign extends Adapter
             'Api-Token: '.$this->apiKey
         ]);
 
-        curl_exec($ch);
+        $data = curl_exec($ch);
 
         if (curl_errno($ch)) {
             return false;

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -106,19 +106,24 @@ class ActiveCampaign extends Adapter
      * @param string $email
      * @param string $firstName
      * @param string $lastName
+     * @param string $phone
      * @return bool
      */
-    public function createContact(string $email, string $firstName, string $lastName): bool
+    public function createContact(string $email, string $firstName = '', string $lastName = '', string $phone = ''): bool
     {
         $ch = curl_init();
+
+        $body = ['contact' => [
+            'email' => $email,
+            'firstName' => $firstName,
+            'lastName' => $lastName,
+            'phone' => $phone
+        ]];
+
         curl_setopt($ch, CURLOPT_URL, 'https://'.$this->organisationID.'.api-us1.com/api/3/contacts');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(['contact' => [
-            'email' => $email,
-            'firstName' => $firstName,
-            'lastName' => $lastName
-        ]]));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(array_filter($body)));
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             'Content-Type: application/json',
             'Api-Token: '.$this->apiKey
@@ -133,6 +138,51 @@ class ActiveCampaign extends Adapter
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         if ($statusCode == 201) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Update contact
+     * 
+     * @param string $email
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $phone
+     * 
+     * @return bool
+     */
+    public function updateContact(string $contactId, string $email = '', string $firstName = '', string $lastName = '', string $phone = ''): bool
+    {
+        $ch = curl_init();
+
+        $body = ['contact' => [
+            'email' => $email,
+            'firstName' => $firstName,
+            'lastName' => $lastName,
+            'phone' => $phone
+        ]];
+
+        curl_setopt($ch, CURLOPT_URL, 'https://'.$this->organisationID.'.api-us1.com/api/3/contacts/'.$contactId);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(array_filter($body)));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Api-Token: '.$this->apiKey
+        ]);
+
+        curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            return false;
+        }
+
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($statusCode == 200) {
             return true;
         } else {
             return false;

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -157,7 +157,7 @@ class ActiveCampaign extends Adapter
      * @param string $email
      * @return bool
      */
-    public function deleteContact($email): bool {
+    public function deleteContact(string $email): bool {
         $contact = $this->contactExists($email);
 
         if (!$contact) {

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Utopia PHP Framework
+ *
+ * @package Analytics
+ * @subpackage Tests
+ *
+ * @link https://github.com/utopia-php/framework
+ * @version 1.0 RC1
+ * @license The MIT License (MIT) <http://www.opensource.org/licenses/mit-license.php>
+ */
+
+namespace Utopia\Analytics\Adapter;
+
+use Utopia\Analytics\Adapter;
+use Utopia\Analytics\Event;
+use Utopia\CLI\Console;
+
+class Plausible extends Adapter
+{
+    /**
+     *  Endpoint for Plausible
+
+     *  @var string
+     */
+    protected string $endpoint = 'https://plausible.io/api';
+
+    /**
+     * Useragent to use for requests
+
+     * @var string
+     */
+    protected string $userAgent = 'Utopia PHP Framework';
+
+    /**
+     * Global Headers
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * Plausible API key
+
+     * @var string
+     */
+    protected string $apiKey;
+
+    /**
+     * Domain to use for events
+     * 
+     * @var string
+     */
+    protected string $domain;
+
+    /**
+     * The IP address to forward to Plausible
+     * 
+     * @var string
+     */
+    protected string $clientIP;
+    
+
+    /**
+     * Gets the name of the adapter.
+     * 
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Plausible';
+    }
+
+    /**
+     * @param string $domain
+     * @param string $apiKey
+     * @param string $useragent
+     * @param string $clientIP
+     * 
+     * @return Plausible
+     */
+
+    public function __construct(string $domain, string $apiKey, string $useragent, string $clientIP)
+    {
+        $this->domain = $domain;
+
+        $this->apiKey = $apiKey;
+
+        $this->userAgent = $useragent;
+
+        $this->clientIP = $clientIP;
+    }
+
+    /**
+     * Sends an event to Plausible.
+     * 
+     * @param Event $event
+     * 
+     * @return bool
+     */
+    public function createEvent(Event $event): bool
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        if (!$this->provisionGoal($event->getName())) {
+            return false;
+        }
+
+        $params = [
+            'url' => $event->getUrl(),
+            'props' => $event->getProps(),
+            'domain' => $this->domain,
+            'name' => $event->getType(),
+        ];
+
+        $headers = [
+            'X-Forwarded-For' => $this->clientIP,
+            'User-Agent' => $this->userAgent,
+            'Content-Type' => 'application/json'
+        ];
+
+        try {
+            $this->call('POST', '/event', $headers, $params);
+            return true;
+        } catch (\Exception $e) {
+            Console::error($e->getMessage());
+            return false;
+        }
+    }
+
+    private function provisionGoal(string $eventName)
+    {
+        $params = [
+            'site_id' => $this->domain,
+            'goal_type' => 'event',
+            'event_name' => $eventName,
+        ];
+
+        $headers = [
+            'Content-Type' => null,
+            'Authorization' => 'Bearer '.$this->apiKey
+        ];
+
+        try {
+            $this->call('PUT', '/v1/sites/goals', $headers, $params);
+            return true;
+        } catch (\Exception $e) {
+            Console::error($e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/Analytics/AnalyticsException.php
+++ b/src/Analytics/AnalyticsException.php
@@ -1,6 +1,0 @@
-<?php
-    namespace Utopia\Analytics;
-
-    class AnalyticsException extends \Exception 
-    {
-    }

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -22,15 +22,24 @@ use Utopia\Analytics\Event;
 class AnalyticsTest extends TestCase
 {
     public $ga;
+    public $ac;
 
     public function setUp(): void
     {
-        $this->ga = new GoogleAnalytics("UA-XXXXXXXXX-X", "test");
-        $this->ac = new ActiveCampaign("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "xxxxxxxxx");
-    }
+        $this->ga = new GoogleAnalytics(getenv("GA_TID"), getenv("GA_CID"));
+        $this->ac = new ActiveCampaign(
+            getenv("AC_KEY"), 
+            getenv("AC_ACTID"),
+            getenv("AC_APIKEY"),
+            getenv("AC_ORGID"),
+            "test@test.com");
+        }
 
     public function testGoogleAnalytics()
     {
+        // Use Measurement Protocol Validation Server for testing.
+        $this->ga->endpoint = "https://www.google-analytics.com/debug/collect";
+
         $pageviewEvent = new Event();
         $pageviewEvent
             ->setType('pageview')
@@ -75,5 +84,17 @@ class AnalyticsTest extends TestCase
         $this->ac->disable();
         $this->assertFalse($this->ac->createEvent($pageviewEvent));
         $this->assertFalse($this->ac->createEvent($normalEvent));
+    }
+
+    public function testActiveCampaignCreateContact() {
+        $this->assertTrue($this->ac->createContact('test@test.com', 'Paul', 'Van Doren'));
+    }
+
+    public function testActiveCampaignGetContact() {
+        $this->assertIsNumeric($this->ac->contactExists('test@test.com'));
+    }
+
+    public function testActiveCampaignDeleteContact() {
+        $this->assertTrue($this->ac->deleteContact('test@test.com'));
     }
 }

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -99,6 +99,9 @@ class AnalyticsTest extends TestCase
         ];
     }
 
+    /**
+     * @depends testActiveCampaignGetContact
+     */
     public function testActiveCampaignUpdateContact($data) {
         $this->assertTrue($this->ac->updateContact($data['contactID'], null, null, null, '7223224241'));
     }

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -93,12 +93,14 @@ class AnalyticsTest extends TestCase
     public function testActiveCampaignGetContact() {
         $contactID = $this->ac->contactExists('test@test.com');
         $this->assertIsNumeric($contactID);
-        $this['contactID'] = $contactID;
-        return $this;
+
+        return [
+            'contactID' => $contactID,
+        ];
     }
 
-    public function testActiveCampaignUpdateContact() {
-        $this->assertTrue($this->ac->updateContact($this['contactID'], null, null, null, '7223224241'));
+    public function testActiveCampaignUpdateContact($data) {
+        $this->assertTrue($this->ac->updateContact($data['contactID'], null, null, null, '7223224241'));
     }
 
     public function testActiveCampaignDeleteContact() {

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -95,7 +95,7 @@ class AnalyticsTest extends TestCase
         $this->assertIsNumeric($contactID);
 
         return [
-            'contactID' => $contactID,
+            'contactID' => $contactID
         ];
     }
 
@@ -103,7 +103,7 @@ class AnalyticsTest extends TestCase
      * @depends testActiveCampaignGetContact
      */
     public function testActiveCampaignUpdateContact($data) {
-        $this->assertTrue($this->ac->updateContact($data['contactID'], null, null, null, '7223224241'));
+        $this->assertTrue($this->ac->updateContact($data['contactID'], 'test@test.com', '', '', '7223224241'));
     }
 
     public function testActiveCampaignDeleteContact() {

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -17,12 +17,14 @@ namespace Utopia\Tests;
 use PHPUnit\Framework\TestCase;
 use Utopia\Analytics\Adapter\ActiveCampaign;
 use Utopia\Analytics\Adapter\GoogleAnalytics;
+use Utopia\Analytics\Adapter\Plausible;
 use Utopia\Analytics\Event;
 
 class AnalyticsTest extends TestCase
 {
     public $ga;
     public $ac;
+    public $pa;
 
     public function setUp(): void
     {
@@ -33,7 +35,9 @@ class AnalyticsTest extends TestCase
             getenv("AC_APIKEY"),
             getenv("AC_ORGID"),
             "test@test.com");
-        }
+        $this->pa = new Plausible(getenv("PA_DOMAIN"), getenv("PA_APIKEY"), 
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "192.168.0.1");
+    }
 
     public function testGoogleAnalytics()
     {
@@ -49,7 +53,6 @@ class AnalyticsTest extends TestCase
         $normalEvent = new Event();
         $normalEvent->setType('testEvent')
             ->setName('testEvent')
-            ->setValue('testEvent')
             ->setUrl('https://www.appwrite.io/docs/installation')
             ->setProps(['category' => 'testEvent']);;
 
@@ -61,29 +64,24 @@ class AnalyticsTest extends TestCase
         $this->assertFalse($this->ga->createEvent($normalEvent));
     }
 
-    public function testActiveCampaign()
+    public function testPlausible()
     {
         $pageviewEvent = new Event();
         $pageviewEvent
             ->setType('pageview')
-            ->setName('pageview')
-            ->addProp('uid', 'test')
-            ->setUrl('https://www.appwrite.io/docs/installation');
+            ->setUrl('https://www.appwrite.io/docs/pageview123');
 
         $normalEvent = new Event();
-        $normalEvent->setType('testEvent')
-            ->setName('testEvent')
-            ->setValue('testEvent')
-            ->addProp('category', 'testEvent')
-            ->addProp('email', 'test@test.com')
-            ->setUrl('https://www.appwrite.io/docs/installation');
-
-        $this->assertTrue($this->ac->createEvent($pageviewEvent));
-        $this->assertTrue($this->ac->createEvent($normalEvent));
-
-        $this->ac->disable();
-        $this->assertFalse($this->ac->createEvent($pageviewEvent));
-        $this->assertFalse($this->ac->createEvent($normalEvent));
+        $normalEvent->setType('myCoolEvent')
+            ->setUrl('https://www.appwrite.io/docs/myCoolEvent123')
+            ->setProps(['category' => 'coolEvent']);;
+    
+         $this->assertTrue($this->pa->createEvent($pageviewEvent));
+         $this->assertTrue($this->pa->createEvent($normalEvent));
+    
+         $this->pa->disable();
+         $this->assertFalse($this->pa->createEvent($pageviewEvent));
+         $this->assertFalse($this->pa->createEvent($normalEvent));
     }
 
     public function testActiveCampaignCreateAccount() {

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -91,7 +91,14 @@ class AnalyticsTest extends TestCase
     }
 
     public function testActiveCampaignGetContact() {
-        $this->assertIsNumeric($this->ac->contactExists('test@test.com'));
+        $contactID = $this->ac->contactExists('test@test.com');
+        $this->assertIsNumeric($contactID);
+        $this['contactID'] = $contactID;
+        return $this;
+    }
+
+    public function testActiveCampaignUpdateContact() {
+        $this->assertTrue($this->ac->updateContact($this['contactID'], null, null, null, '7223224241'));
     }
 
     public function testActiveCampaignDeleteContact() {

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -86,17 +86,46 @@ class AnalyticsTest extends TestCase
         $this->assertFalse($this->ac->createEvent($normalEvent));
     }
 
+    public function testActiveCampaignCreateAccount() {
+        $this->assertTrue($this->ac->createAccount(
+            'Appwrite',
+            'appwrite.io',
+            1,
+        ));
+    }
+
+    public function testActiveCampaignGetAccount() {
+        $accountID = $this->ac->accountExists('Appwrite');
+        $this->assertIsNumeric($accountID);
+
+        return [
+            'accountID' => $accountID,
+        ];
+    }
+
     public function testActiveCampaignCreateContact() {
         $this->assertTrue($this->ac->createContact('test@test.com', 'Paul', 'Van Doren'));
     }
 
-    public function testActiveCampaignGetContact() {
+    /**
+     * @depends testActiveCampaignGetAccount
+     */
+    public function testActiveCampaignGetContact($data) {
         $contactID = $this->ac->contactExists('test@test.com');
         $this->assertIsNumeric($contactID);
 
         return [
-            'contactID' => $contactID
+            'contactID' => $contactID,
+            'accountID' => $data['accountID'],
         ];
+    }
+
+    /**
+     * @depends testActiveCampaignGetContact
+     */
+    public function testActiveCampaignSyncAsociation($data) {
+        $this->assertTrue($this->ac->syncAssociation($data['accountID'], $data['contactID'], 'Owner'));
+        $this->assertTrue($this->ac->syncAssociation($data['accountID'], $data['contactID'], 'Software Developer'));
     }
 
     /**
@@ -108,5 +137,23 @@ class AnalyticsTest extends TestCase
 
     public function testActiveCampaignDeleteContact() {
         $this->assertTrue($this->ac->deleteContact('test@test.com'));
+    }
+
+    /**
+     * @depends testActiveCampaignGetAccount
+     */
+    public function testActiveCampaignUpdateAccount($data) {
+        $this->assertTrue($this->ac->updateAccount(
+            $data['accountID'], 
+            'Utopia', 
+            'utopia.com', 
+            1));
+    }
+
+    /**
+     * @depends testActiveCampaignGetAccount
+     */
+    public function testActiveCampaignDeleteAccount($data) {
+        $this->assertTrue($this->ac->deleteAccount($data['accountID']));
     }
 }


### PR DESCRIPTION
Adding these methods will allow us to easily check if a contact exists and create one if it doesn't so we are sure our events get logged.