### PR TITLE
Add IP and User Agent Methods to Adapters

### DIFF
--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -66,22 +66,30 @@ abstract class Adapter
     public abstract function send(Event $event): bool;
 
     /**
-     * Sets the useragent to use for requests.
+     * Sets the client IP address.
      * 
-     * @param string $userAgent The useragent to use for requests.
+     * @param string $ip The IP address to use.
      * 
-     * @return void
+     * @return self
      */
-    abstract public function setUserAgent(string $userAgent): void;
+    public function setClientIP(string $clientIP): self
+    {
+        $this->ip = $clientIP;
+        return $this;
+    }
 
     /**
-     * Sets the clientIP to use for requests.
+     * Sets the client user agent.
      * 
-     * @param string $clientIP The clientIP to use for requests.
+     * @param string $userAgent The user agent to use.
      * 
-     * @return void
+     * @return self
      */
-    abstract public function setClientIP(string $clientIP): void;
+    public function setUserAgent(string $userAgent): self
+    {
+        $this->userAgent = $userAgent;
+        return $this;
+    }
 
     /**
      * Creates an Event on the remote analytics platform.

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -22,6 +22,20 @@ abstract class Adapter
     protected bool $enabled = true;
 
     /**
+     * Useragent to use for requests
+
+     * @var string
+     */
+    protected string $userAgent = 'Utopia PHP Framework';
+
+    /**
+     * The IP address to forward to Plausible
+     * 
+     * @var string
+     */
+    protected string $clientIP;
+
+    /**
      * Gets the name of the adapter.
      * 
      * @return string

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -66,6 +66,24 @@ abstract class Adapter
     public abstract function send(Event $event): bool;
 
     /**
+     * Sets the useragent to use for requests.
+     * 
+     * @param string $userAgent The useragent to use for requests.
+     * 
+     * @return void
+     */
+    abstract public function setUserAgent(string $userAgent): void;
+
+    /**
+     * Sets the clientIP to use for requests.
+     * 
+     * @param string $clientIP The clientIP to use for requests.
+     * 
+     * @return void
+     */
+    abstract public function setClientIP(string $clientIP): void;
+
+    /**
      * Creates an Event on the remote analytics platform.
      * 
      * @param Event $event

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -381,10 +381,11 @@ class ActiveCampaign extends Adapter
      * 
      * @param string $ip The IP address to use.
      * 
-     * @return void
+     * @return self
      */
-    public function setClientIP(string $clientIP): void
+    public function setClientIP(string $clientIP): self
     {
+        throw new \Exception('Not implemented');
     }
 
     /**
@@ -392,9 +393,10 @@ class ActiveCampaign extends Adapter
      * 
      * @param string $userAgent The user agent to use.
      * 
-     * @return void
+     * @return self
      */
-    public function setUserAgent(string $userAgent): void
+    public function setUserAgent(string $userAgent): self
     {
+        throw new \Exception('Not implemented');
     }
 }

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -19,7 +19,6 @@ namespace Utopia\Analytics\Adapter;
 
 use Utopia\Analytics\Adapter;
 use Utopia\Analytics\Event;
-use Utopia\CLI\Console;
 
 class ActiveCampaign extends Adapter
 {

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -375,4 +375,26 @@ class ActiveCampaign extends Adapter
         $this->call('POST', 'https://trackcmp.net/event', [], $query); // Active Campaign event URL, Refer to https://developers.activecampaign.com/reference/track-event/ for more details
         return true;
     }
+
+    /**
+     * Sets the client IP address.
+     * 
+     * @param string $ip The IP address to use.
+     * 
+     * @return void
+     */
+    public function setClientIP(string $clientIP): void
+    {
+    }
+
+    /**
+     * Sets the client user agent.
+     * 
+     * @param string $userAgent The user agent to use.
+     * 
+     * @return void
+     */
+    public function setUserAgent(string $userAgent): void
+    {
+    }
 }

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -38,19 +38,6 @@ class GoogleAnalytics extends Adapter
     private string $cid;
 
     /**
-     * Client IP Address
-     * @var string
-     */
-    private string $ip;
-
-    /**
-     * Client user agent
-     * 
-     * @var string
-     */
-    private string $userAgent;
-
-    /**
      * Gets the name of the adapter.
      * 
      * @return string
@@ -99,7 +86,7 @@ class GoogleAnalytics extends Adapter
             'dp' => parse_url($event->getUrl())['path'],
             'dt' => $event->getProp('documentTitle'),
             't' => $event->getType(),
-            'uip' => $this->ip ?? "",
+            'uip' => $this->clientIP ?? "",
             'ua' => $this->userAgent ?? "",
         ];
         

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -80,9 +80,9 @@ class GoogleAnalytics extends Adapter
      * 
      * @return void
      */
-    public function setClientIP(string $ip)
+    public function setClientIP(string $clientIP): void
     {
-        $this->ip = $ip;
+        $this->ip = $clientIP;
     }
 
     /**
@@ -92,7 +92,7 @@ class GoogleAnalytics extends Adapter
      * 
      * @return void
      */
-    public function setUserAgent(string $userAgent)
+    public function setUserAgent(string $userAgent): void
     {
         $this->userAgent = $userAgent;
     }

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -74,30 +74,6 @@ class GoogleAnalytics extends Adapter
     }
 
     /**
-     * Sets the client IP address.
-     * 
-     * @param string $ip The IP address to use.
-     * 
-     * @return void
-     */
-    public function setClientIP(string $clientIP): void
-    {
-        $this->ip = $clientIP;
-    }
-
-    /**
-     * Sets the client user agent.
-     * 
-     * @param string $userAgent The user agent to use.
-     * 
-     * @return void
-     */
-    public function setUserAgent(string $userAgent): void
-    {
-        $this->userAgent = $userAgent;
-    }
-
-    /**
      * Creates an Event on the remote analytics platform.
      * 
      * @param Event $event

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -123,8 +123,8 @@ class GoogleAnalytics extends Adapter
             'dp' => parse_url($event->getUrl())['path'],
             'dt' => $event->getProp('documentTitle'),
             't' => $event->getType(),
-            'uip' => $this->ip,
-            'ua' => $this->userAgent,
+            'uip' => $this->ip ?? "",
+            'ua' => $this->userAgent ?? "",
         ];
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -44,6 +44,13 @@ class GoogleAnalytics extends Adapter
     private string $ip;
 
     /**
+     * Client user agent
+     * 
+     * @var string
+     */
+    private string $userAgent;
+
+    /**
      * Gets the name of the adapter.
      * 
      * @return string
@@ -79,6 +86,18 @@ class GoogleAnalytics extends Adapter
     }
 
     /**
+     * Sets the client user agent.
+     * 
+     * @param string $userAgent The user agent to use.
+     * 
+     * @return void
+     */
+    public function setUserAgent(string $userAgent)
+    {
+        $this->userAgent = $userAgent;
+    }
+
+    /**
      * Creates an Event on the remote analytics platform.
      * 
      * @param Event $event
@@ -105,6 +124,7 @@ class GoogleAnalytics extends Adapter
             'dt' => $event->getProp('documentTitle'),
             't' => $event->getType(),
             'uip' => $this->ip,
+            'ua' => $this->userAgent,
         ];
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -38,6 +38,12 @@ class GoogleAnalytics extends Adapter
     private string $cid;
 
     /**
+     * Client IP Address
+     * @var string
+     */
+    private string $ip;
+
+    /**
      * Gets the name of the adapter.
      * 
      * @return string
@@ -58,6 +64,18 @@ class GoogleAnalytics extends Adapter
     {
         $this->tid = $tid;
         $this->cid = $cid;
+    }
+
+    /**
+     * Sets the client IP address.
+     * 
+     * @param string $ip The IP address to use.
+     * 
+     * @return void
+     */
+    public function setClientIP(string $ip)
+    {
+        $this->ip = $ip;
     }
 
     /**
@@ -85,7 +103,8 @@ class GoogleAnalytics extends Adapter
             'dh' => parse_url($event->getUrl())['host'],
             'dp' => parse_url($event->getUrl())['path'],
             'dt' => $event->getProp('documentTitle'),
-            't' => $event->getType()
+            't' => $event->getType(),
+            'uip' => $this->ip,
         ];
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');

--- a/src/Analytics/Adapter/Orbit.php
+++ b/src/Analytics/Adapter/Orbit.php
@@ -103,10 +103,11 @@ class Orbit extends Adapter
      * 
      * @param string $ip The IP address to use.
      * 
-     * @return void
+     * @return self
      */
-    public function setClientIP(string $clientIP): void
+    public function setClientIP(string $clientIP): self
     {
+        throw new \Exception('Not implemented');
     }
 
     /**
@@ -114,9 +115,10 @@ class Orbit extends Adapter
      * 
      * @param string $userAgent The user agent to use.
      * 
-     * @return void
+     * @return self
      */
-    public function setUserAgent(string $userAgent): void
+    public function setUserAgent(string $userAgent): self
     {
+        throw new \Exception('Not implemented');
     }
 }

--- a/src/Analytics/Adapter/Orbit.php
+++ b/src/Analytics/Adapter/Orbit.php
@@ -97,4 +97,26 @@ class Orbit extends Adapter
 
         return true;
     }
+
+    /**
+     * Sets the client IP address.
+     * 
+     * @param string $ip The IP address to use.
+     * 
+     * @return void
+     */
+    public function setClientIP(string $clientIP): void
+    {
+    }
+
+    /**
+     * Sets the client user agent.
+     * 
+     * @param string $userAgent The user agent to use.
+     * 
+     * @return void
+     */
+    public function setUserAgent(string $userAgent): void
+    {
+    }
 }

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -27,13 +27,6 @@ class Plausible extends Adapter
     protected string $endpoint = 'https://plausible.io/api';
 
     /**
-     * Useragent to use for requests
-
-     * @var string
-     */
-    protected string $userAgent = 'Utopia PHP Framework';
-
-    /**
      * Global Headers
      *
      * @var array
@@ -53,13 +46,6 @@ class Plausible extends Adapter
      * @var string
      */
     protected string $domain;
-
-    /**
-     * The IP address to forward to Plausible
-     * 
-     * @var string
-     */
-    protected string $clientIP;
     
 
     /**

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -91,30 +91,6 @@ class Plausible extends Adapter
     }
 
     /**
-     * Sets the useragent to use for requests.
-     * 
-     * @param string $userAgent The useragent to use for requests.
-     * 
-     * @return void
-     */
-    public function setUserAgent(string $userAgent): void
-    {
-        $this->userAgent = $userAgent;
-    }
-
-    /**
-     * Sets the clientIP to use for requests.
-     * 
-     * @param string $clientIP The clientIP to use for requests.
-     * 
-     * @return void
-     */
-    public function setClientIP(string $clientIP): void
-    {
-        $this->clientIP = $clientIP;
-    }
-
-    /**
      * Sends an event to Plausible.
      * 
      * @param Event $event The event to send.

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -73,14 +73,15 @@ class Plausible extends Adapter
     }
 
     /**
-     * @param string $domain
-     * @param string $apiKey
-     * @param string $useragent
-     * @param string $clientIP
+     * Constructor.
+     * 
+     * @param string $domain    The domain to use for events
+     * @param string $apiKey    The API key to use for requests
+     * @param string $useragent The useragent to use for requests
+     * @param string $clientIP  The IP address to forward to Plausible
      * 
      * @return Plausible
      */
-
     public function __construct(string $domain, string $apiKey, string $useragent, string $clientIP)
     {
         $this->domain = $domain;
@@ -90,9 +91,33 @@ class Plausible extends Adapter
     }
 
     /**
+     * Sets the useragent to use for requests.
+     * 
+     * @param string $userAgent The useragent to use for requests.
+     * 
+     * @return void
+     */
+    public function setUserAgent(string $userAgent): void
+    {
+        $this->userAgent = $userAgent;
+    }
+
+    /**
+     * Sets the clientIP to use for requests.
+     * 
+     * @param string $clientIP The clientIP to use for requests.
+     * 
+     * @return void
+     */
+    public function setClientIP(string $clientIP): void
+    {
+        $this->clientIP = $clientIP;
+    }
+
+    /**
      * Sends an event to Plausible.
      * 
-     * @param Event $event
+     * @param Event $event The event to send.
      * 
      * @return bool
      */
@@ -126,7 +151,8 @@ class Plausible extends Adapter
     /**
      * Provision a goal for the given event.
      * 
-     * @param string $eventName
+     * @param string $eventName The name of the event.
+     * 
      * @return bool
      */
     private function provisionGoal(string $eventName): bool


### PR DESCRIPTION
This PR adds `setUserAgent` and `setClientIP` methods to the plausible and google analytics adapter to allow easy modification of those variables once set without reinitialising the constructor.