### PR TITLE
Add Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
 - 8.0
-- nightly
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",
-        "vimeo/psalm": "4.0.1"
+        "vimeo/psalm": "^5.6"
     }
 }

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -24,6 +24,13 @@ abstract class Adapter
     protected string $clientIP;
 
     /**
+     * Endpoint
+     * 
+     * @var string
+     */
+    protected string $endpoint;
+
+    /**
      * Gets the name of the adapter.
      * 
      * @return string
@@ -66,6 +73,15 @@ abstract class Adapter
      * @return bool
      */
     public abstract function send(Event $event): bool;
+
+    /**
+     * Validate the adapter.
+     * Sends a test event to the adapter and validates if it was received.
+     * 
+     * @param Event $event
+     * @return bool
+     */
+    public abstract function validate(Event $event): bool;
 
     /**
      * Sets the client IP address.

--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -78,8 +78,11 @@ abstract class Adapter
      * Validate the adapter.
      * Sends a test event to the adapter and validates if it was received.
      * 
+     * Throws an exception if the adapter is not valid.
+     * 
      * @param Event $event
      * @return bool
+     * @throws Exception
      */
     public abstract function validate(Event $event): bool;
 

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -429,9 +429,6 @@ class ActiveCampaign extends Adapter
 
         $email = $event->getProp('email');
 
-        $name = 'testEvent_' . chr(mt_rand(97, 122)) . substr(md5(time()), 1, 5);
-        $event->setName($name);
-
         if (empty($email)) {
             throw new \Exception("Email is required.");
         }
@@ -455,7 +452,7 @@ class ActiveCampaign extends Adapter
         }
 
         foreach ($response['trackingLogs'] as $log) {
-            if ($log['type'] === $name) {
+            if ($log['type'] === $event->getName()) {
                 $foundLog = true;
                 break;
             }

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -441,27 +441,6 @@ class ActiveCampaign extends Adapter
         }
 
         $contactID = $this->contactExists($email);
-
-        if (!$contactID) {
-            $this->createContact(
-                $email,
-                "Amadeus",
-                "Test"
-            );
-
-            $contactID = $this->contactExists($email);
-        }
-
-        $event->addProp('email', $email);
-
-        $activeCampaignStatus = $this->createEvent($event);
-
-        if (!$activeCampaignStatus) {
-            throw new \Exception("Failed to create event on ActiveCampaign.");
-        }
-
-        sleep(2);
-
         $foundLog = false;
 
         // Get contact again, since AC doesn't refresh logs immediately

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -433,11 +433,11 @@ class ActiveCampaign extends Adapter
         $event->setName($name);
 
         if (empty($email)) {
-            return false;
+            throw new \Exception("Email is required.");
         }
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            return false;
+            throw new \Exception("Invalid email address.");
         }
 
         $contactID = $this->contactExists($email);
@@ -457,7 +457,7 @@ class ActiveCampaign extends Adapter
         $activeCampaignStatus = $this->createEvent($event);
 
         if (!$activeCampaignStatus) {
-            return false;
+            throw new \Exception("Failed to create event on ActiveCampaign.");
         }
 
         sleep(2);
@@ -471,6 +471,10 @@ class ActiveCampaign extends Adapter
 
         $response = json_decode($response, true);
 
+        if (empty($response['trackingLogs'])) {
+            throw new \Exception("Failed to find event on ActiveCampaign side.");
+        }
+
         foreach ($response['trackingLogs'] as $log) {
             if ($log['type'] === $name) {
                 $foundLog = true;
@@ -478,6 +482,10 @@ class ActiveCampaign extends Adapter
             }
         }
 
-        return boolval($foundLog);
+        if (!$foundLog) {
+            throw new \Exception("Failed to find event on ActiveCampaign side.");
+        }
+
+        return true;
     }
 }

--- a/src/Analytics/Adapter/ActiveCampaign.php
+++ b/src/Analytics/Adapter/ActiveCampaign.php
@@ -442,7 +442,8 @@ class ActiveCampaign extends Adapter
 
         // Get contact again, since AC doesn't refresh logs immediately
         $response = $this->call('GET', '/api/3/activities', [], [
-            'contact' => $contactID
+            'contact' => $contactID,
+            'orders[tstamp]' => 'DESC'
         ]);
 
         $response = json_decode($response, true);

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -71,9 +71,38 @@ class GoogleAnalytics extends Adapter
             throw new \Exception('Event name is required');
         }
 
-        global $lastResult;
+        $query = [
+            'ec' => $event->getProp('category'),
+            'ea' => $event->getProp('action'),
+            'el' => $event->getName(),
+            'ev' => $event->getValue(),
+            'dh' => parse_url($event->getUrl())['host'],
+            'dp' => parse_url($event->getUrl())['path'],
+            'dt' => $event->getProp('documentTitle'),
+            't' => $event->getType(),
+            'uip' => $this->clientIP ?? "",
+            'ua' => $this->userAgent ?? "",
+            'sr' => $event->getProp('screenResolution'),
+            'vp' => $event->getProp('viewportSize'),
+            'dr' => $event->getProp('referrer'),
+        ];
 
-        return $lastResult;
+        $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');
+
+        $validateResponse = $this->call('POST', $this->debugEndpoint, [], array_merge(
+            $query,
+            [
+                'tid' => $this->tid,
+                'cid' => $this->cid,
+                'v' => 1
+            ]
+        ));
+
+        if (json_decode($validateResponse)->hitParsingResult[0]->valid !== true) {
+            throw new \Exception('Invalid event');
+        }
+
+        return true;
     }
 
     /**
@@ -119,7 +148,7 @@ class GoogleAnalytics extends Adapter
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');
 
-        $result = $this->call('POST',  isset($event->getProp('heartbeat')) ?  $this->debugEndpoint : $this->endpoint, [], array_merge([
+        $result = $this->call('POST',  null !== $event->getProp('heartbeat') ?  $this->debugEndpoint : $this->endpoint, [], array_merge([
             'tid' => $this->tid,
             'cid' => $this->cid,
             'v' => 1

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -14,6 +14,11 @@ class GoogleAnalytics extends Adapter
     public string $endpoint = 'https://www.google-analytics.com/collect';
 
     /**
+     * Endpoint for Google Analytics Debug
+     */
+    public string $debugEndpoint = 'https://www.google-analytics.com/debug/collect';
+
+    /**
      * Tracking ID for Google Analytics
      * @var string
      */
@@ -66,35 +71,9 @@ class GoogleAnalytics extends Adapter
             throw new \Exception('Event name is required');
         }
 
-        $query = [
-            'ec' => $event->getProp('category'),
-            'ea' => $event->getProp('action'),
-            'el' => $event->getName(),
-            'ev' => $event->getValue(),
-            'dh' => parse_url($event->getUrl())['host'],
-            'dp' => parse_url($event->getUrl())['path'],
-            'dt' => $event->getProp('documentTitle'),
-            't' => 'event',
-            'uip' => $this->clientIP ?? "",
-            'ua' => $this->userAgent ?? "",
-            'sr' => $event->getProp('screenResolution'),
-            'vp' => $event->getProp('viewportSize'),
-            'dr' => $event->getProp('referrer'),
-        ];
+        global $lastResult;
 
-        $result = $this->call("POST", "https://www.google-analytics.com/debug/collect", [], array_merge([
-            'tid' => $this->tid,
-            'cid' => $this->cid,
-            'v' => 1
-        ], $query));
-
-        foreach (json_decode($result, true)['hitParsingResult'] as $hit) {
-            if ($hit['valid'] == false) {
-                throw new \Exception($hit['parserMessage']);
-            }
-        }
-
-        return true;
+        return $lastResult;
     }
 
     /**
@@ -140,7 +119,7 @@ class GoogleAnalytics extends Adapter
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');
 
-        $result = $this->call('POST', $this->endpoint, [], array_merge([
+        $result = $this->call('POST',  isset($event->getProp('heartbeat')) ?  $this->debugEndpoint : $this->endpoint, [], array_merge([
             'tid' => $this->tid,
             'cid' => $this->cid,
             'v' => 1

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -150,7 +150,7 @@ class GoogleAnalytics extends Adapter
         
         $query = array_filter($query, fn($value) => !is_null($value) && $value !== '');
 
-        $result = $this->call('POST',  null !== $event->getProp('heartbeat') ?  $this->debugEndpoint : $this->endpoint, [], array_merge([
+        $result = $this->call('POST', $this->endpoint, [], array_merge([
             'tid' => $this->tid,
             'cid' => $this->cid,
             'v' => 1

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -79,7 +79,7 @@ class GoogleAnalytics extends Adapter
             'dh' => parse_url($event->getUrl())['host'],
             'dp' => parse_url($event->getUrl())['path'],
             'dt' => $event->getProp('documentTitle'),
-            't' => $event->getType(),
+            't' => ($event->getType() === 'pageview') ? 'pageview' : 'event',
             'uip' => $this->clientIP ?? "",
             'ua' => $this->userAgent ?? "",
             'sr' => $event->getProp('screenResolution'),
@@ -98,7 +98,9 @@ class GoogleAnalytics extends Adapter
             ]
         ));
 
-        if (json_decode($validateResponse)->hitParsingResult[0]->valid !== true) {
+        $validateResponse = json_decode($validateResponse, true);
+
+        if ($validateResponse['hitParsingResult'][0]['valid'] !== true) {
             throw new \Exception('Invalid event');
         }
 

--- a/src/Analytics/Adapter/GoogleAnalytics.php
+++ b/src/Analytics/Adapter/GoogleAnalytics.php
@@ -55,15 +55,15 @@ class GoogleAnalytics extends Adapter
         }
 
         if (empty($event->getType())) {
-            return false;
+            throw new \Exception('Event type is required');
         }
 
         if (empty($event->getUrl())) {
-            return false;
+            throw new \Exception('Event URL is required');
         }
 
         if (empty($event->getName())) {
-            return false;
+            throw new \Exception('Event name is required');
         }
 
         $query = [
@@ -90,7 +90,7 @@ class GoogleAnalytics extends Adapter
 
         foreach (json_decode($result, true)['hitParsingResult'] as $hit) {
             if ($hit['valid'] == false) {
-                return false;
+                throw new \Exception($hit['parserMessage']);
             }
         }
 

--- a/src/Analytics/Adapter/Orbit.php
+++ b/src/Analytics/Adapter/Orbit.php
@@ -135,23 +135,23 @@ class Orbit extends Adapter
         }
 
         if (empty($event->getType())) {
-            return false;
+            throw new \Exception('Event type is required');
         }
 
         if (empty($event->getUrl())) {
-            return false;
+            throw new \Exception('Event URL is required');
         }
 
         if (empty($event->getName())) {
-            return false;
+            throw new \Exception('Event name is required');
         }
 
         if (empty($event->getProp('email'))) {
-            return false;
+            throw new \Exception('Event email is required');
         }
 
         if (!$this->send($event)) {
-            return false;
+            throw new \Exception('Failed to send event');
         }
 
         // Check if event made it.
@@ -179,7 +179,7 @@ class Orbit extends Adapter
         $activities = json_decode($activities, true);
 
         if (empty($activities['data'])) {
-            return false;
+            throw new \Exception('Failed to find event in Orbit');
         }
 
         $foundActivity = false;
@@ -191,7 +191,7 @@ class Orbit extends Adapter
         }
 
         if (!$foundActivity) {
-            return false;
+            throw new \Exception('Failed to find event in Orbit');
         }
 
         $this->call('DELETE',  '/members/'.$member['id'].'/activities/'.$foundActivity, [

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -151,7 +151,7 @@ class Plausible extends Adapter
             throw new Exception('Event URL is required');
         }
 
-        $validateURL = 'https://plausible.io/api/v1/stats/aggregate?' . http_build_query([
+        $validateURL = $this->endpoint . '/v1/stats/aggregate?' . http_build_query([
             'site_id' => $this->domain,
             'filters' => json_encode(["goal" => $event->getName()]),
         ]);

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -13,6 +13,7 @@
 
 namespace Utopia\Analytics\Adapter;
 
+use Exception;
 use Utopia\Analytics\Adapter;
 use Utopia\Analytics\Event;
 use Utopia\CLI\Console;
@@ -46,7 +47,7 @@ class Plausible extends Adapter
      * @var string
      */
     protected string $domain;
-    
+
 
     /**
      * Gets the name of the adapter.
@@ -129,10 +130,61 @@ class Plausible extends Adapter
 
         $headers = [
             'Content-Type' => 'application/x-www-form-urlencoded',
-            'Authorization' => 'Bearer '.$this->apiKey
+            'Authorization' => 'Bearer ' . $this->apiKey
         ];
 
         $this->call('PUT', '/v1/sites/goals', $headers, $params);
         return true;
+    }
+
+    public function validate(Event $event): bool
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        if (empty($event->getType())) {
+            return false;
+        }
+
+        if (empty($event->getUrl())) {
+            return false;
+        }
+
+        $name = 'testEvent_' . chr(mt_rand(97, 122)) . substr(md5(time()), 1);
+
+        if (!$this->provisionGoal($name)) {
+            return false;
+        }
+
+        $params = [
+            'url' => $event->getUrl(),
+            'props' => $event->getProps(),
+            'domain' => $this->domain,
+            'name' => $name,
+            'referrer' => $event->getProp('referrer'),
+            'screen_width' => $event->getProp('screenWidth'),
+        ];
+
+        $headers = [
+            'X-Forwarded-For' => $this->clientIP,
+            'User-Agent' => $this->userAgent,
+            'Content-Type' => 'application/json'
+        ];
+
+        $response = $this->call('POST', '/event', $headers, $params);
+
+        $validateURL = 'https://plausible.io/api/v1/stats/aggregate?' . http_build_query([
+            'site_id' => $this->domain,
+            'filters' => json_encode(["goal" => $name]),
+        ]);
+
+        $checkCreated = $this->call('GET', $validateURL, [
+            'Content-Type' => '',
+            'Authorization' => 'Bearer ' . $this->apiKey
+        ]);
+        $checkCreated = json_decode($checkCreated, true);
+
+        return $checkCreated['results']['visitors']['value'] > 0;
     }
 }

--- a/src/Analytics/Adapter/Plausible.php
+++ b/src/Analytics/Adapter/Plausible.php
@@ -151,36 +151,9 @@ class Plausible extends Adapter
             throw new Exception('Event URL is required');
         }
 
-        $name = 'testEvent_' . chr(mt_rand(97, 122)) . substr(md5(time()), 1);
-
-        if (!$this->provisionGoal($name)) {
-            throw new Exception('Failed to provision goal');
-        }
-
-        $params = [
-            'url' => $event->getUrl(),
-            'props' => $event->getProps(),
-            'domain' => $this->domain,
-            'name' => $name,
-            'referrer' => $event->getProp('referrer'),
-            'screen_width' => $event->getProp('screenWidth'),
-        ];
-
-        $headers = [
-            'X-Forwarded-For' => $this->clientIP,
-            'User-Agent' => $this->userAgent,
-            'Content-Type' => 'application/json'
-        ];
-
-        $response = $this->call('POST', '/event', $headers, $params);
-
-        if ($response !== 'ok') {
-            throw new Exception('Failed to send event');
-        }
-
         $validateURL = 'https://plausible.io/api/v1/stats/aggregate?' . http_build_query([
             'site_id' => $this->domain,
-            'filters' => json_encode(["goal" => $name]),
+            'filters' => json_encode(["goal" => $event->getName()]),
         ]);
 
         $checkCreated = $this->call('GET', $validateURL, [

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -86,12 +86,10 @@ class AnalyticsTest extends TestCase
             ->setUrl('https://www.appwrite.io/docs/installation')
             ->setProps(['category' => 'testEvent']);;
 
-         $this->assertTrue($this->pa->validate($pageviewEvent));
-         $this->assertTrue($this->pa->validate($normalEvent));
-
-         $this->pa->disable();
-         $this->assertFalse($this->pa->validate($pageviewEvent));
-         $this->assertFalse($this->pa->validate($normalEvent));
+        $this->assertTrue($this->pa->send($pageviewEvent));
+        $this->assertTrue($this->pa->validate($pageviewEvent));
+        $this->assertTrue($this->pa->send($normalEvent));
+        $this->assertTrue($this->pa->validate($normalEvent));
     }
 
     public function testActiveCampaignCreateContact() {
@@ -167,6 +165,7 @@ class AnalyticsTest extends TestCase
             ->setUrl('https://www.appwrite.io/docs/installation')
             ->setProps(['category' => 'analytics:test', 'email' => 'paul@vans.com', 'tags' => ['test', 'test2']]);
 
+        $this->assertTrue($this->ac->send($event));
         $this->assertTrue($this->ac->validate($event));
     }
 
@@ -178,6 +177,7 @@ class AnalyticsTest extends TestCase
             ->setUrl('https://www.appwrite.io/docs/installation')
             ->setProps(['category' => 'testEvent', 'email' => 'paul@vans.com', 'tags' => ['test', 'test2']]);
 
+        $this->assertTrue($this->orbit->send($event));
         $this->assertTrue($this->orbit->validate($event));
     }
 }

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -8,6 +8,7 @@ use Utopia\Analytics\Adapter\GoogleAnalytics;
 use Utopia\Analytics\Adapter\Orbit;
 use Utopia\Analytics\Adapter\Plausible;
 use Utopia\Analytics\Event;
+use Utopia\App;
 
 class AnalyticsTest extends TestCase
 {
@@ -26,28 +27,28 @@ class AnalyticsTest extends TestCase
     public function __construct()
     {
         parent::__construct();
-        $this->ga = new GoogleAnalytics(getenv("GA_TID"), getenv("GA_CID"));
+        $this->ga = new GoogleAnalytics(App::getEnv("GA_TID"), App::getEnv("GA_CID"));
         $this->ac = new ActiveCampaign(
-            getenv("AC_KEY"),
-            getenv("AC_ACTID"),
-            getenv("AC_APIKEY"),
-            getenv("AC_ORGID")
+            App::getEnv("AC_KEY"),
+            App::getEnv("AC_ACTID"),
+            App::getEnv("AC_APIKEY"),
+            App::getEnv("AC_ORGID")
         );
-        $this->pa = new Plausible(getenv("PA_DOMAIN"), getenv("PA_APIKEY"), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "192.168.0.1");
-        $this->orbit = new Orbit(getenv("OR_WORKSPACEID"), getenv("OR_APIKEY"), "Utopia Testing Suite");
+        $this->pa = new Plausible(App::getEnv("PA_DOMAIN"), App::getEnv("PA_APIKEY"), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "192.168.0.1");
+        $this->orbit = new Orbit(App::getEnv("OR_WORKSPACEID"), App::getEnv("OR_APIKEY"), "Utopia Testing Suite");
     }
 
     public function setUp(): void
     {
-        $this->ga = new GoogleAnalytics(getenv("GA_TID"), getenv("GA_CID"));
+        $this->ga = new GoogleAnalytics(App::getEnv("GA_TID"), App::getEnv("GA_CID"));
         $this->ac = new ActiveCampaign(
-            getenv("AC_KEY"),
-            getenv("AC_ACTID"),
-            getenv("AC_APIKEY"),
-            getenv("AC_ORGID")
+            App::getEnv("AC_KEY"),
+            App::getEnv("AC_ACTID"),
+            App::getEnv("AC_APIKEY"),
+            App::getEnv("AC_ORGID")
         );
-        $this->pa = new Plausible(getenv("PA_DOMAIN"), getenv("PA_APIKEY"), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "192.168.0.1");
-        $this->orbit = new Orbit(getenv("OR_WORKSPACEID"), getenv("OR_APIKEY"), "Utopia Testing Suite");
+        $this->pa = new Plausible(App::getEnv("PA_DOMAIN"), App::getEnv("PA_APIKEY"), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "192.168.0.1");
+        $this->orbit = new Orbit(App::getEnv("OR_WORKSPACEID"), App::getEnv("OR_APIKEY"), "Utopia Testing Suite");
     }
 
     public function testGoogleAnalytics(): void
@@ -82,22 +83,21 @@ class AnalyticsTest extends TestCase
 
         $normalEvent = new Event();
         $normalEvent->setType('testEvent')
-            ->setName('testEvent')
+            ->setName('testEvent'.chr(mt_rand(97, 122)).substr(md5(time()), 1, 5))
             ->setUrl('https://www.appwrite.io/docs/installation')
             ->setProps(['category' => 'testEvent']);;
 
         $this->assertTrue($this->pa->send($pageviewEvent));
-        $this->assertTrue($this->pa->validate($pageviewEvent));
         $this->assertTrue($this->pa->send($normalEvent));
         $this->assertTrue($this->pa->validate($normalEvent));
     }
 
     public function testActiveCampaignCreateContact() {
-        $this->assertTrue($this->ac->createContact('test@test.com', 'Paul', 'Van Doren'));
+        $this->assertTrue($this->ac->createContact('analytics2@utopiaphp.com', 'Analytics', 'Utopia'));
     }
 
     public function testActiveCampaignGetContact() {
-        $contactID = $this->ac->contactExists('test@test.com');
+        $contactID = $this->ac->contactExists('analytics2@utopiaphp.com');
         $this->assertIsNumeric($contactID);
 
         return [
@@ -133,11 +133,11 @@ class AnalyticsTest extends TestCase
      * @depends testActiveCampaignGetContact
      */
     public function testActiveCampaignUpdateContact($data) {
-        $this->assertTrue($this->ac->updateContact($data['contactID'], 'test@test.com', '', '', '7223224241'));
+        $this->assertTrue($this->ac->updateContact($data['contactID'], 'analytics2@utopiaphp.com', '', '', '7223224241'));
     }
 
     public function testActiveCampaignDeleteContact() {
-        $this->assertTrue($this->ac->deleteContact('test@test.com'));
+        $this->assertTrue($this->ac->deleteContact('analytics2@utopiaphp.com'));
     }
 
     /**
@@ -159,13 +159,16 @@ class AnalyticsTest extends TestCase
     }
 
     public function testActiveCampaign() {
+        $this->assertTrue($this->ac->createContact('analytics@utopiaphp.com', 'Analytics', 'Utopia'));
+
         $event = new Event();
         $event->setType('testEvent')
-            ->setName('testEvent')
+            ->setName('testEvent'.chr(mt_rand(97, 122)).substr(md5(time()), 1, 5))
             ->setUrl('https://www.appwrite.io/docs/installation')
-            ->setProps(['category' => 'analytics:test', 'email' => 'paul@vans.com', 'tags' => ['test', 'test2']]);
+            ->setProps(['category' => 'analytics:test', 'email' => 'analytics@utopiaphp.com', 'tags' => ['test', 'test2']]);
 
         $this->assertTrue($this->ac->send($event));
+        sleep(1);
         $this->assertTrue($this->ac->validate($event));
     }
 
@@ -175,9 +178,24 @@ class AnalyticsTest extends TestCase
         $event->setType('testEvent')
             ->setName('testEvent')
             ->setUrl('https://www.appwrite.io/docs/installation')
-            ->setProps(['category' => 'testEvent', 'email' => 'paul@vans.com', 'tags' => ['test', 'test2']]);
+            ->setProps(['category' => 'testEvent', 'email' => 'analytics@utopiaphp.com', 'tags' => ['test', 'test2']]);
 
         $this->assertTrue($this->orbit->send($event));
         $this->assertTrue($this->orbit->validate($event));
+    }
+
+    function testCleanup(): void
+    {
+        if ($this->ac->contactExists('analytics@utopiaphp.com')) {
+            $this->assertTrue($this->ac->deleteContact('analytics@utopiaphp.com'));
+        }
+
+        if ($this->ac->contactExists('analytics2@utopiaphp.com')) {
+            $this->assertTrue($this->ac->deleteContact('analytics2@utopiaphp.com'));
+        }
+
+        if ($this->ac->accountExists('Example Account 1')) {
+            $this->assertTrue($this->ac->deleteAccount($this->ac->accountExists('Example Account 1')));
+        }
     }
 }

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -168,7 +168,7 @@ class AnalyticsTest extends TestCase
             ->setProps(['category' => 'analytics:test', 'email' => 'analytics@utopiaphp.com', 'tags' => ['test', 'test2']]);
 
         $this->assertTrue($this->ac->send($event));
-        sleep(1);
+        sleep(10);
         $this->assertTrue($this->ac->validate($event));
     }
 


### PR DESCRIPTION
This PR adds a validate($event) function to all adapters which will create the event, check the event was successfully created then finally delete the event (if possible) and return true if it was all success or false if an error occoured.

It can be used as a quick san check for adapters.