### PR TITLE
Add new methods and fix old ones

### DIFF
--- a/src/Analytics/Adapter/HubSpot.php
+++ b/src/Analytics/Adapter/HubSpot.php
@@ -182,7 +182,7 @@ class HubSpot extends Adapter
         }
     }
 
-    /** 
+    /**
      * Get Property
      */
     public function getContactProperty(string $contactId, string $property)

--- a/src/Analytics/Adapter/HubSpot.php
+++ b/src/Analytics/Adapter/HubSpot.php
@@ -86,6 +86,24 @@ class HubSpot extends Adapter
     }
 
     /**
+     * Get Contact
+     */
+    public function getContact(string $contactId)
+    {
+        try {
+            $result = $this->call('GET', '/crm/v3/objects/contacts/'.$contactId, [
+                'Content-Type' => 'application/json',
+            ]);
+
+            return json_decode($result, true);
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return false;
+        }
+    }
+
+    /**
      * Create a contact
      */
     public function createContact(string $email, string $firstName = '', string $lastName = '', string $phone = ''): bool
@@ -164,6 +182,26 @@ class HubSpot extends Adapter
         }
     }
 
+    /** 
+     * Get Property
+     */
+    public function getContactProperty(string $contactId, string $property)
+    {
+        try {
+            $result = $this->call('GET', '/crm/v3/objects/contacts/'.$contactId.'?properties='.urlencode($property), [
+                'Content-Type' => 'application/json',
+            ]);
+
+            $data = json_decode($result, true);
+
+            return $data['properties'][$property] ?? [];
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return false;
+        }
+    }
+
     /**
      * Account Exists
      */
@@ -224,15 +262,18 @@ class HubSpot extends Adapter
     /**
      * Update an account
      */
-    public function updateAccount(string $accountId, string $name, string $url = '', int $ownerId = 1, array $fields = []): bool
+    public function updateAccount(string $accountId, array $fields): bool
     {
         $body = [
-            'name' => $name,
-            'domain' => $url,
+            'properties' => [],
         ];
 
+        foreach ($fields as $key => $value) {
+            $body['properties'][$key] = $value;
+        }
+
         try {
-            $this->call('PATCH', '/crm/v3/objects/companies/'.$accountId, [
+            $this->call('PATCH', '/crm/v3/objects/contacts/'.$accountId, [
                 'Content-Type' => 'application/json',
             ], $body);
 

--- a/src/Analytics/Adapter/HubSpot.php
+++ b/src/Analytics/Adapter/HubSpot.php
@@ -262,13 +262,19 @@ class HubSpot extends Adapter
     /**
      * Update an account
      */
-    public function updateAccount(string $accountId, string $name, string $url = '', array $fields = []): bool
+    public function updateAccount(string $accountId, string $name = '', string $url = '', array $fields = []): bool
     {
         $body = [
-            'name' => $name,
-            'domain' => $url,
             'properties' => [],
         ];
+
+        if ($name) {
+            $body['name'] = $name;
+        }
+
+        if ($url) {
+            $body['domain'] = $url;
+        }
 
         foreach ($fields as $key => $value) {
             $body['properties'][$key] = $value;

--- a/src/Analytics/Adapter/HubSpot.php
+++ b/src/Analytics/Adapter/HubSpot.php
@@ -262,9 +262,11 @@ class HubSpot extends Adapter
     /**
      * Update an account
      */
-    public function updateAccount(string $accountId, array $fields): bool
+    public function updateAccount(string $accountId, string $name, string $url = '', array $fields = []): bool
     {
         $body = [
+            'name' => $name,
+            'domain' => $url,
             'properties' => [],
         ];
 

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -190,10 +190,8 @@ class AnalyticsTest extends TestCase
     {
         $this->assertTrue($this->hs->updateAccount(
             $data['accountID'],
-            [
-                'name' => 'Utopia',
-                'website' => 'utopia.com',
-            ]
+            'Utopia',
+            'utopia.com'
         ));
 
         return $data;

--- a/tests/Analytics/AnalyticsTest.php
+++ b/tests/Analytics/AnalyticsTest.php
@@ -190,9 +190,10 @@ class AnalyticsTest extends TestCase
     {
         $this->assertTrue($this->hs->updateAccount(
             $data['accountID'],
-            'Utopia',
-            'utopia.com',
-            1
+            [
+                'name' => 'Utopia',
+                'website' => 'utopia.com',
+            ]
         ));
 
         return $data;


### PR DESCRIPTION
This PR adds 2 new methods to hubspot: getContact and getContactProperty and also fixes an old method updateAccount while changing the signature to better match hubspot instead of AC