### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -136,56 +136,52 @@ abstract class Adapter
             unset($headers[$i]);
         }
 
-        try {
-            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_USERAGENT, php_uname('s').'-'.php_uname('r').':php-'.phpversion());
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-            curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
-                $len = strlen($header);
-                $header = explode(':', strtolower($header), 2);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_USERAGENT, php_uname('s').'-'.php_uname('r').':php-'.phpversion());
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
+            $len = strlen($header);
+            $header = explode(':', strtolower($header), 2);
 
-                if (count($header) < 2) { // ignore invalid headers
-                    return $len;
-                }
-
-                $responseHeaders[strtolower(trim($header[0]))] = trim($header[1]);
-
+            if (count($header) < 2) { // ignore invalid headers
                 return $len;
-            });
-
-            if ($method != 'GET') {
-                curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
             }
 
-            $responseBody = curl_exec($ch);
+            $responseHeaders[strtolower(trim($header[0]))] = trim($header[1]);
 
-            $responseType = $responseHeaders['Content-Type'] ?? '';
-            $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            return $len;
+        });
 
-            switch (substr($responseType, 0, strpos($responseType, ';'))) {
-                case 'application/json':
-                    $responseBody = json_decode($responseBody, true);
-                    break;
-            }
-
-            if (curl_errno($ch)) {
-                throw new Exception(curl_error($ch), $responseStatus);
-            }
-
-            if ($responseStatus >= 400) {
-                if (is_array($responseBody)) {
-                    throw new Exception(json_encode($responseBody), $responseStatus);
-                } else {
-                    throw new Exception($responseStatus.': '.$responseBody, $responseStatus);
-                }
-            }
-
-            return $responseBody;
-        } finally {
-            curl_close($ch);
+        if ($method != 'GET') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
         }
+
+        $responseBody = curl_exec($ch);
+
+        $responseType = $responseHeaders['Content-Type'] ?? '';
+        $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        switch (substr($responseType, 0, strpos($responseType, ';'))) {
+            case 'application/json':
+                $responseBody = json_decode($responseBody, true);
+                break;
+        }
+
+        if (curl_errno($ch)) {
+            throw new Exception(curl_error($ch), $responseStatus);
+        }
+
+        if ($responseStatus >= 400) {
+            if (is_array($responseBody)) {
+                throw new Exception(json_encode($responseBody), $responseStatus);
+            } else {
+                throw new Exception($responseStatus.': '.$responseBody, $responseStatus);
+            }
+        }
+
+        return $responseBody;
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
