### PR TITLE
Fix PHP 8.5 curl_close() deprecation

### DIFF
--- a/src/Analytics/Adapter.php
+++ b/src/Analytics/Adapter.php
@@ -184,7 +184,6 @@ abstract class Adapter
 
             return $responseBody;
         } finally {
-            curl_close($ch);
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the no-op `curl_close($ch)` call in `Analytics\Adapter` that triggers a `Deprecated` notice on PHP 8.5.

## Why
`curl_close()` has been a no-op since PHP 8.0 and is now formally deprecated in 8.5. The curl handle is freed when the variable goes out of scope.

## Test plan
- [x] `composer lint` (Pint) — pass
- [x] `php -l src/Analytics/Adapter.php` — clean

(Note: this repo does not define a `composer analyze`/PHPStan script; lint is the configured gate.)